### PR TITLE
Develop slither.io collision avoidance

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -124,8 +124,8 @@ export class Bot {
 	 * Checks if god mode assist should take control (independent of bot)
 	 */
 	public checkGodModeAssist(): boolean {
-		if (!window.ourSnake || !window.playing) return false;
-		return godModeAssist.checkAndAssist(window.ourSnake);
+		if (!window.slither || !window.playing) return false;
+		return godModeAssist.checkAndAssist(window.slither);
 	}
 
 	/**

--- a/src/bot/god-mode.ts
+++ b/src/bot/god-mode.ts
@@ -313,12 +313,12 @@ export class GodModeAssist {
 	 * Set mouse direction for steering
 	 */
 	private setMouseDirection(targetAngle: number): void {
-		if (!window.ourSnake) return;
+		if (!window.slither) return;
 
 		// Convert to screen coordinates for mouse positioning
 		const mouseDistance = 200; // Distance from snake center
-		const targetX = window.ourSnake.xx + Math.cos(targetAngle) * mouseDistance;
-		const targetY = window.ourSnake.yy + Math.sin(targetAngle) * mouseDistance;
+		const targetX = window.slither.xx + Math.cos(targetAngle) * mouseDistance;
+		const targetY = window.slither.yy + Math.sin(targetAngle) * mouseDistance;
 
 		// Convert to canvas coordinates
 		const canvasX = (targetX - window.view_xx) * window.gsc + window.canvas.width / 2;
@@ -343,15 +343,15 @@ export class GodModeAssist {
 			return;
 		}
 		
-		if (!window.ourSnake) {
-			console.log("🔧 No ourSnake for god mode visuals");
+		if (!window.slither) {
+			console.log("🔧 No slither for god mode visuals");
 			return;
 		}
 		
 		console.log("🔧 Drawing god mode visuals...");
 
 		const ctx = window.ctx;
-		const ourSnake = window.ourSnake;
+		const ourSnake = window.slither;
 
 		// Map our snake to canvas
 		const snakeScreen = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const init = () => {
 		original_oef();
 
 		// God Mode Assist - works independently of bot
-		if (window.playing && window.ourSnake !== null) {
+		if (window.playing && window.slither !== null) {
 			checkGodModeAssist();
 			
 			// Draw god mode visuals independently
@@ -38,7 +38,7 @@ const init = () => {
 		}
 
 		// Bot behavior
-		if (window.playing && botEnabledState.val && window.ourSnake !== null) {
+		if (window.playing && botEnabledState.val && window.slither !== null) {
 			isBotRunning = true;
 			bot.go();
 		} else if (botEnabledState.val && isBotRunning) {
@@ -49,8 +49,8 @@ const init = () => {
 			}
 		}
 
-		if (window.ourSnake !== null) {
-			lengthState.val = bot.getSnakeLength(window.ourSnake);
+		if (window.slither !== null) {
+			lengthState.val = bot.getSnakeLength(window.slither);
 		}
 	};
 

--- a/userscript/bot.user.js
+++ b/userscript/bot.user.js
@@ -422,10 +422,10 @@ The MIT License (MIT)
      * Set mouse direction for steering
      */
     setMouseDirection(targetAngle) {
-      if (!window.ourSnake) return;
+      if (!window.slither) return;
       const mouseDistance = 200;
-      const targetX = window.ourSnake.xx + Math.cos(targetAngle) * mouseDistance;
-      const targetY = window.ourSnake.yy + Math.sin(targetAngle) * mouseDistance;
+      const targetX = window.slither.xx + Math.cos(targetAngle) * mouseDistance;
+      const targetY = window.slither.yy + Math.sin(targetAngle) * mouseDistance;
       const canvasX = (targetX - window.view_xx) * window.gsc + window.canvas.width / 2;
       const canvasY = (targetY - window.view_yy) * window.gsc + window.canvas.height / 2;
       window.xm = canvasX;
@@ -442,13 +442,13 @@ The MIT License (MIT)
         console.log("\u{1F527} No canvas context for god mode visuals");
         return;
       }
-      if (!window.ourSnake) {
-        console.log("\u{1F527} No ourSnake for god mode visuals");
+      if (!window.slither) {
+        console.log("\u{1F527} No slither for god mode visuals");
         return;
       }
       console.log("\u{1F527} Drawing god mode visuals...");
       const ctx = window.ctx;
-      const ourSnake = window.ourSnake;
+      const ourSnake = window.slither;
       const snakeScreen = {
         x: (ourSnake.xx - window.view_xx) * window.gsc + window.canvas.width / 2,
         y: (ourSnake.yy - window.view_yy) * window.gsc + window.canvas.height / 2
@@ -580,8 +580,8 @@ The MIT License (MIT)
      * Checks if god mode assist should take control (independent of bot)
      */
     checkGodModeAssist() {
-      if (!window.ourSnake || !window.playing) return false;
-      return godModeAssist.checkAndAssist(window.ourSnake);
+      if (!window.slither || !window.playing) return false;
+      return godModeAssist.checkAndAssist(window.slither);
     }
     /**
      * Draws god mode visuals independently
@@ -2047,13 +2047,13 @@ The MIT License (MIT)
         fpsState.val = window.fps;
       }
       original_oef();
-      if (window.playing && window.ourSnake !== null) {
+      if (window.playing && window.slither !== null) {
         checkGodModeAssist();
         if (bot.isGodModeVisualsEnabled()) {
           bot.drawGodModeVisuals();
         }
       }
-      if (window.playing && botEnabledState.val && window.ourSnake !== null) {
+      if (window.playing && botEnabledState.val && window.slither !== null) {
         isBotRunning = true;
         bot.go();
       } else if (botEnabledState.val && isBotRunning) {
@@ -2062,8 +2062,8 @@ The MIT License (MIT)
           window.connect();
         }
       }
-      if (window.ourSnake !== null) {
-        lengthState.val = bot.getSnakeLength(window.ourSnake);
+      if (window.slither !== null) {
+        lengthState.val = bot.getSnakeLength(window.slither);
       }
     };
     window.connect = () => {


### PR DESCRIPTION
Fix God Mode and visuals not working by correcting snake reference.

This PR addresses a critical bug where God Mode and its visual debugging were non-functional because the code was referencing `window.ourSnake` instead of the correct `window.slither` for the player's snake. This prevented any testing or use of the God Mode features.

---

[Open in Web](https://www.cursor.com/agents?id=bc-5f6c8281-98e2-4933-bc9a-8d5f5c82e42f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5f6c8281-98e2-4933-bc9a-8d5f5c82e42f)